### PR TITLE
fix UI bottom bar

### DIFF
--- a/lib/screens/meal/custom_meal_screen.dart
+++ b/lib/screens/meal/custom_meal_screen.dart
@@ -41,6 +41,7 @@ class _CustomMealScreenState extends State<CustomMealScreen>
     return Consumer<CustomMealProvider>(
       builder: (context, customMealProvider, child) {
         return NavBar(
+          currentIndex: 2,
           body: Container(
             color: Color(0xFFF5EFE7),
             child: Column(

--- a/lib/screens/menumeal/menu_meal_screen.dart
+++ b/lib/screens/menumeal/menu_meal_screen.dart
@@ -82,6 +82,7 @@ class _MenuMealScreenState extends State<MenuMealScreen> with SingleTickerProvid
     return Consumer<CartProvider>(
       builder: (context, cartProvider, child) {
         return NavBar(
+          currentIndex: 0,
           cartCount: cartProvider.cartItemCount,
           body: Container(
             color: AppColors.background,

--- a/lib/screens/profile/profile_screen.dart
+++ b/lib/screens/profile/profile_screen.dart
@@ -51,6 +51,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
     final user = authProvider.currentUser;
 
     return NavBar(
+      currentIndex: 4,
       cartCount: 3,
       body: Container(
         color: Color(0xFFF5F5F5),

--- a/lib/screens/week_meal/week_meal_screen.dart
+++ b/lib/screens/week_meal/week_meal_screen.dart
@@ -26,6 +26,7 @@ class _WeekMealScreenState extends State<WeekMealScreen> with SingleTickerProvid
   @override
   Widget build(BuildContext context) {
     return NavBar(
+      currentIndex: 3,
       cartCount: 3,
       body: SingleChildScrollView(
         child: Padding(

--- a/lib/widgets/nav_bar.dart
+++ b/lib/widgets/nav_bar.dart
@@ -4,17 +4,20 @@ import 'package:provider/provider.dart';
 import 'package:green_kitchen_app/provider/auth_provider.dart';
 import 'package:green_kitchen_app/provider/cart_provider.dart';
 import 'package:green_kitchen_app/constants/app_constants.dart';
+import 'package:green_kitchen_app/theme/app_colors.dart';
 
 class NavBar extends StatefulWidget {
   final int cartCount;
   final VoidCallback? onCartTap;
   final Widget body;
+  final int currentIndex;
 
   const NavBar({
     super.key,
     this.cartCount = 0,
     this.onCartTap,
     required this.body,
+    this.currentIndex = 0,
   });
 
   @override
@@ -22,8 +25,6 @@ class NavBar extends StatefulWidget {
 }
 
 class _NavBarState extends State<NavBar> {
-  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-
   @override
   void initState() {
     super.initState();
@@ -37,36 +38,23 @@ class _NavBarState extends State<NavBar> {
     });
   }
 
-  Future<void> _handleLogout() async {
-    final authProvider = Provider.of<AuthProvider>(context, listen: false);
-
-    // Show confirmation dialog
-    final shouldLogout = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Logout'),
-        content: const Text('Are you sure you want to logout?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            style: TextButton.styleFrom(foregroundColor: Colors.red),
-            child: const Text('Logout'),
-          ),
-        ],
-      ),
-    );
-
-    if (shouldLogout == true) {
-      await authProvider.logout();
-
-      if (mounted) {
-        // Navigate back to login screen
-        GoRouter.of(context).go('/');
-      }
+  void _onBottomNavTap(int index) {
+    switch (index) {
+      case 0:
+        GoRouter.of(context).go('/menumeal');
+        break;
+      case 1:
+        GoRouter.of(context).go('/menumeal');
+        break;
+      case 2:
+        GoRouter.of(context).go('/custommeal');
+        break;
+      case 3:
+        GoRouter.of(context).go('/weekmeal');
+        break;
+      case 4:
+        GoRouter.of(context).go('/profile');
+        break;
     }
   }
 
@@ -76,104 +64,7 @@ class _NavBarState extends State<NavBar> {
     final user = authProvider.currentUser;
 
     return Scaffold(
-      key: _scaffoldKey,
-      backgroundColor: const Color(0xFFF8F5E7),
-      drawer: Drawer(
-        child: ListView(
-          padding: EdgeInsets.zero,
-          children: <Widget>[
-            DrawerHeader(
-              decoration: const BoxDecoration(
-                color: Color(0xFF1CC29F),
-              ),
-              child: GestureDetector(
-                onTap: () {
-                  Navigator.pop(context);
-                  GoRouter.of(context).go('/profile');
-                },
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    CircleAvatar(
-                      radius: 32,
-                      backgroundColor: Colors.white,
-                      child: Icon(Icons.person, size: 40, color: Color(0xFF1CC29F)),
-                    ),
-                    SizedBox(height: 12),
-                    Text(
-                      user?.fullName ?? user?.firstName ?? 'Green User',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontWeight: FontWeight.bold,
-                        fontSize: 20,
-                      ),
-                    ),
-                    if (user?.email != null)
-                      Text(
-                        user!.email,
-                        style: TextStyle(
-                          color: Colors.white70,
-                          fontSize: 14,
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-            ),
-            ListTile(
-              leading: const Icon(Icons.home),
-              title: const Text('Menu Meal'),
-              onTap: () {
-                Navigator.pop(context);
-                GoRouter.of(context).go('/menumeal');
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.article),
-              title: const Text('Articles'),
-              onTap: () {
-                Navigator.pop(context);
-                GoRouter.of(context).go('/articles');
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.restaurant_menu),
-              title: const Text('Custom Meal'),
-              onTap: () {
-                Navigator.pop(context);
-                GoRouter.of(context).go('/custommeal');
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.calendar_today),
-              title: const Text('Week Meal'),
-              onTap: () {
-                Navigator.pop(context);
-                GoRouter.of(context).go('/weekmeal');
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.settings),
-              title: const Text('Settings'),
-              onTap: () {
-                Navigator.pop(context);
-              },
-            ),
-            const Divider(),
-            ListTile(
-              leading: const Icon(Icons.logout, color: Colors.red),
-              title: const Text(
-                'Logout',
-                style: TextStyle(color: Colors.red),
-              ),
-              onTap: () {
-                Navigator.pop(context); // Close drawer first
-                _handleLogout();
-              },
-            ),
-          ],
-        ),
-      ),
+      backgroundColor: AppColors.background,
       body: SafeArea(
         child: Column(
           children: [
@@ -181,19 +72,38 @@ class _NavBarState extends State<NavBar> {
               elevation: 2,
               child: Container(
                 padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                color: const Color(0xFFF8F5E7),
+                color: AppColors.background,
                 child: Row(
                   children: [
-                    IconButton(
-                      icon: const Icon(Icons.menu, color: Colors.black87),
-                      onPressed: () => _scaffoldKey.currentState?.openDrawer(),
+                    GestureDetector(
+                      onTap: () {
+                        GoRouter.of(context).go('/profile');
+                      },
+                      child: CircleAvatar(
+                        radius: 20,
+                        backgroundColor: AppColors.secondary,
+                        child: user?.fullName != null && user!.fullName!.isNotEmpty
+                            ? Text(
+                                user.fullName![0].toUpperCase(),
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 16,
+                                ),
+                              )
+                            : const Icon(
+                                Icons.person,
+                                color: Colors.white,
+                                size: 24,
+                              ),
+                      ),
                     ),
                     Expanded(
                       child: Center(
                         child: const Text(
                           'GREEN KITCHEN',
                           style: TextStyle(
-                            color: Color(0xFF1CC29F),
+                            color: AppColors.secondary,
                             fontWeight: FontWeight.bold,
                             fontSize: 24,
                             letterSpacing: 1.2,
@@ -201,13 +111,15 @@ class _NavBarState extends State<NavBar> {
                         ),
                       ),
                     ),
-                    // Sử dụng Consumer để badge tự động cập nhật khi cartProvider thay đổi
                     Consumer<CartProvider>(
                       builder: (context, cartProvider, child) {
                         return Stack(
                           children: [
                             IconButton(
-                              icon: const Icon(Icons.shopping_cart, color: Colors.black87),
+                              icon: Icon(
+                                Icons.shopping_cart,
+                                color: AppColors.textPrimary,
+                              ),
                               onPressed: widget.onCartTap ?? () {
                                 GoRouter.of(context).go('/cart');
                               },
@@ -219,7 +131,7 @@ class _NavBarState extends State<NavBar> {
                                 child: Container(
                                   padding: const EdgeInsets.all(4),
                                   decoration: const BoxDecoration(
-                                    color: Color(0xFF1CC29F),
+                                    color: AppColors.secondary,
                                     shape: BoxShape.circle,
                                   ),
                                   child: Text(
@@ -244,10 +156,49 @@ class _NavBarState extends State<NavBar> {
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        backgroundColor: const Color(0xFF4B0036),
-        onPressed: () {},
-        child: const Icon(Icons.chat, color: Colors.white),
+      bottomNavigationBar: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          boxShadow: [
+            BoxShadow(
+              color: AppColors.shadow,
+              blurRadius: 10,
+              offset: const Offset(0, -2),
+            ),
+          ],
+        ),
+        child: BottomNavigationBar(
+          currentIndex: widget.currentIndex,
+          onTap: _onBottomNavTap,
+          type: BottomNavigationBarType.fixed,
+          backgroundColor: Colors.white,
+          selectedItemColor: AppColors.secondary,
+          unselectedItemColor: AppColors.textSecondary,
+          selectedFontSize: 12,
+          unselectedFontSize: 12,
+          items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.home),
+              label: 'Home',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.restaurant_menu),
+              label: 'Menu',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.food_bank),
+              label: 'Custom Meal',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.calendar_today),
+              label: 'Week Meal',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.person),
+              label: 'Account',
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
This pull request refactors the navigation experience across multiple screens by replacing the legacy drawer-based navigation with a bottom navigation bar (`BottomNavigationBar`) and updating related UI elements for consistency. It also introduces a new `currentIndex` property to the `NavBar` widget, allowing each screen to highlight its corresponding tab in the navigation bar.

**Navigation overhaul:**

* Replaced the side drawer navigation in `NavBar` with a persistent bottom navigation bar, improving accessibility and user experience. The new navigation bar includes five tabs: Home, Menu, Custom Meal, Week Meal, and Account. (`lib/widgets/nav_bar.dart`)
* Introduced a new `currentIndex` property to the `NavBar` widget, allowing each screen to specify which navigation tab should be active. (`lib/widgets/nav_bar.dart`)

**Screen updates for navigation:**

* Updated `CustomMealScreen`, `MenuMealScreen`, `ProfileScreen`, and `WeekMealScreen` to pass the appropriate `currentIndex` value to the `NavBar`, ensuring the correct tab is highlighted for each screen. (`lib/screens/meal/custom_meal_screen.dart`, `lib/screens/menumeal/menu_meal_screen.dart`, `lib/screens/profile/profile_screen.dart`, `lib/screens/week_meal/week_meal_screen.dart`) [[1]](diffhunk://#diff-5dc7899621f35d11e0d2a551b39ac57214d0acf05520c71e38899377ec8a0905R44) [[2]](diffhunk://#diff-ffed8f348fe1bb1a464706fdcbf6e19cae655b04741c40ce1784374fc0dcade8R85) [[3]](diffhunk://#diff-dd76362ec0363f4f87a216498d4c683355124a1bcc5d31faf27375861d7dd5a3R54) [[4]](diffhunk://#diff-642520143660122841146fe850a79c341001a3bcb45e238c6e83feebd4253c97R29)

**UI consistency and theming:**

* Refactored various UI elements in `NavBar` to use the centralized color palette from `AppColors` for backgrounds, icons, and text, ensuring consistent theming across the app. (`lib/widgets/nav_bar.dart`) [[1]](diffhunk://#diff-caec6481020ffcffd01d141a8d4c916343115e3e30867c6150d0967af791474fL79-R122) [[2]](diffhunk://#diff-caec6481020ffcffd01d141a8d4c916343115e3e30867c6150d0967af791474fL222-R134)

**Navigation logic simplification:**

* Removed the legacy drawer, floating action button, and logout logic from `NavBar`, and implemented a new `_onBottomNavTap` method to handle navigation between screens based on the selected tab. (`lib/widgets/nav_bar.dart`) [[1]](diffhunk://#diff-caec6481020ffcffd01d141a8d4c916343115e3e30867c6150d0967af791474fL40-R57) [[2]](diffhunk://#diff-caec6481020ffcffd01d141a8d4c916343115e3e30867c6150d0967af791474fL79-R122) [[3]](diffhunk://#diff-caec6481020ffcffd01d141a8d4c916343115e3e30867c6150d0967af791474fL247-R201)